### PR TITLE
Revert changes made for nvmed_info

### DIFF
--- a/include/lib_nvmed.h
+++ b/include/lib_nvmed.h
@@ -137,7 +137,6 @@ typedef struct nvmed_device_info NVMED_DEVICE_INFO;
 typedef struct nvmed {
 	char*	ns_path;
 	int 	ns_fd;
-	int		dev_fd;			// Added for nvmed_info
 	u32 	flags;
 	
 	NVMED_DEVICE_INFO *dev_info;

--- a/include/nvme_hdr.h
+++ b/include/nvme_hdr.h
@@ -116,33 +116,6 @@ struct nvme_dsm_cmd {
 	__u32			rsvd12[4];
 };
 
-struct nvme_passthru_cmd {
-    __u8    opcode;
-    __u8    flags;
-    __u16   rsvd1;
-    __u32   nsid;
-    __u32   cdw2;
-    __u32   cdw3;
-    __u64   metadata;
-    __u64   addr;
-    __u32   metadata_len;
-    __u32   data_len;
-    __u32   cdw10;
-    __u32   cdw11;
-    __u32   cdw12;
-    __u32   cdw13;
-    __u32   cdw14;
-    __u32   cdw15;
-    __u32   timeout_ms;
-    __u32   result;
-};
-
-#define nvme_admin_cmd nvme_passthru_cmd
-
-
-
-
-
 struct nvme_completion {
 	__le32	result;		/* Used by admin commands to return data */
 	__u32	rsvd;

--- a/include/nvmed.h
+++ b/include/nvmed.h
@@ -30,10 +30,6 @@
 #define NVMED_IOCTL_GET_USER		_IOWR('N', 0x70, struct nvmed_user_quota)
 #define NVMED_IOCTL_SET_USER		_IOWR('N', 0x71, struct nvmed_user_quota)
 
-// For nvmed_info (borrowed from <linux/nvme_ioctl.h>
-// This ioctl() should be done to nvmed->dev_fd
-#define NVMED_IOCTL_ADMIN_CMD		_IOWR('N', 0x41, struct nvme_admin_cmd)
-
 #define NVMED_CACHE_INIT_NUM_PAGES	2560	
 
 #define SQ_SIZE(depth)		(depth * sizeof(struct nvme_command))

--- a/library/lib_nvmed.c
+++ b/library/lib_nvmed.c
@@ -703,7 +703,6 @@ NVMED* nvmed_open(char* path, int flags) {
 	// Getting NVMe Device Info
 	nvmed->ns_path = admin_path;
 	nvmed->ns_fd = fd;
-	nvmed->dev_fd = devfd;
 	nvmed->dev_info = dev_info;
 	nvmed->flags = flags;
 
@@ -757,7 +756,6 @@ int nvmed_close(NVMED* nvmed) {
 	if(nvmed->numQueue) return -NVMED_FAULT;
 
 	close(nvmed->ns_fd);
-	close(nvmed->dev_fd);
 
 	free(nvmed->ns_path);
 


### PR DESCRIPTION
I have found that I don't even need nvmed->dev_fd and other NVMe stuffs that I've put into the nvme_hdr.h. So, I'm removing the changes made for nvmed_info. Sorry for the mess!