### PR TITLE
 Fixes Segfault on fio with multiple jobfiles

### DIFF
--- a/example/fio_plugin/nvmed_fio.c
+++ b/example/fio_plugin/nvmed_fio.c
@@ -133,10 +133,6 @@ static void fio_nvmed_cleanup(struct thread_data *td)
 	free(nvmed_io_handle->iocq);
 	free(nvmed_io_handle);
 
-	if(nvmed.active_queue == 0) {
-		nvmed_close(nvmed.nvmed);
-		nvmed.nvmed = NULL;
-	}
 
     pthread_mutex_unlock(&nvmed.mutex);
 }
@@ -285,6 +281,10 @@ static int fio_nvmed_queue(struct thread_data *td, struct io_u *io_u)
  */
 static int fio_nvmed_open(struct thread_data *td, struct fio_file *f)
 {
+	if(nvmed.nvmed == NULL) {
+		nvmed.nvmed = nvmed_open((char*)f->file_name, 0);
+		nvmed.dev_size = nvmed.nvmed->dev_info->capacity;
+	}
     return 0;
 }
 
@@ -293,6 +293,10 @@ static int fio_nvmed_open(struct thread_data *td, struct fio_file *f)
  */
 static int fio_nvmed_close(struct thread_data *td, struct fio_file *f)
 {
+	if(nvmed.active_queue == 0) {
+		nvmed_close(nvmed.nvmed);
+		nvmed.nvmed = NULL;
+	}
     return 0;
 }
 

--- a/example/fio_plugin/nvmed_fio.c
+++ b/example/fio_plugin/nvmed_fio.c
@@ -8,12 +8,12 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -85,7 +85,7 @@ static int fio_nvmed_init(struct thread_data *td)
 	NVMED_QUEUE *queue;
 	NVMED_HANDLE *handle;
 	nvmed_io_handle = calloc(1, sizeof(nvmed_io_thread_t));
-	
+
     pthread_mutex_lock(&nvmed.mutex);
 
 	queue = nvmed_queue_create(nvmed.nvmed, 0);
@@ -129,7 +129,7 @@ static void fio_nvmed_cleanup(struct thread_data *td)
 	nvmed_queue_destroy(queue);
 
 	nvmed.active_queue--;
-	
+
 	free(nvmed_io_handle->iocq);
 	free(nvmed_io_handle);
 
@@ -321,7 +321,7 @@ static int fio_nvmed_io_u_init(struct thread_data *td, struct io_u *io_u)
 	nvmed_iou->td = td;
 	nvmed_iou->io_u = io_u;
 	io_u->engine_data = nvmed_iou;
-	
+
     return 0;
 }
 


### PR DESCRIPTION
When running fio with multiple jobfiles the nvmed_fio driver segfaults.
The reason is because the fio_nvmed_io_u_init is called for the second
jobfile and the nvmed.nvmed is NULL resulting in a null pointer
dereference when calling nvmed_get_buffer(nvmed.nvmed, ...).

The reason is because the nvmed dev file was closed by fio_nvmed_cleanup
after the first execution. As the dev file should be open throughout the
execution of the fio, moved the nvmed open and close to the open/close
functions.