### PR TITLE
Adds error checking to mmap error in lib

### DIFF
--- a/library/lib_nvmed.c
+++ b/library/lib_nvmed.c
@@ -371,6 +371,10 @@ NVMED_HANDLE* nvmed_handle_create(NVMED_QUEUE* nvmed_queue, int flags) {
 	nvmed_handle->pa_prpBuf = calloc(1, sizeof(u64) * nvmed_handle->prpBuf_size);
 	tempPtr = mmap(NULL, PAGE_SIZE * nvmed_handle->prpBuf_size, PROT_READ | PROT_WRITE,
 			MAP_ANONYMOUS | MAP_LOCKED | MAP_SHARED, -1, 0);
+    if (tempPtr == MAP_FAILED) {
+        perror("Error with Mmap! If error is resource busy, check mlock limit");
+        return NULL;
+    }
 
 	memset(tempPtr, 0, PAGE_SIZE * nvmed_handle->prpBuf_size);
 


### PR DESCRIPTION
The default mlock allowance on my system was 64KB. NVMeDirect requested
for 64 * 4KB locked pages, resulting in a mmap fail.
However the library does not handle a mmap fail, and thus a segfault
occurs when trying to clear to mmaped region.

This commit adds mmap fail handling, and also suggests checking the mlock
limit.