### PR TITLE
Fixes return value overflow in nvmed_lseek

### DIFF
--- a/library/lib_nvmed.c
+++ b/library/lib_nvmed.c
@@ -1552,7 +1552,7 @@ ssize_t nvmed_io_rw(NVMED_HANDLE* nvmed_handle, u8 opcode, void* buf,
 }
 
 off_t nvmed_lseek(NVMED_HANDLE* nvmed_handle, off_t offset, int whence) {
-	int ret = -1;
+	off_t ret = -1;
 
 	if(whence == SEEK_SET) {
 		if(offset < HtoD(nvmed_handle)->dev_info->capacity) {


### PR DESCRIPTION
The nvmed_lseek return type is defined as off_t in the prototype.
However, internally an int type is used, and so offset values exceeding
2^31 will overflow to a negative number.
This commit changes it to off_t to prevent the overflow.