### PR TITLE
convert start_sect unit in sectors to bytes to calculate start_lba

### DIFF
--- a/library/lib_nvmed.c
+++ b/library/lib_nvmed.c
@@ -1014,7 +1014,7 @@ ssize_t nvmed_io(NVMED_HANDLE* nvmed_handle, u8 opcode,
 	memset(cmnd, 0, sizeof(*cmnd));
 
 	//remap start_lba
-	start_lba += nvmed->dev_info->start_sect;
+	start_lba += nvmed->dev_info->start_sect << nvmed->dev_info->lba_shift;
 
 	switch(opcode) {
 		case nvme_cmd_flush:


### PR DESCRIPTION
Problem Description:
nvmedirect code calculates start_lba incorrectly when the device is a disk partition, therefore I/O goes to wrong location if the device is a disk partition.

Fix:
start_lba is in unit of bytes while start_sect is in unit of sectors. The fix is to convert the unit when calculating the end result of start_lba.

Test Done:
Tested example/nvmed_example/nvmed_example.c works correctly after the fix.